### PR TITLE
feat: 답변 컬럼 추가 및 질문 상세 조회 API 구현

### DIFF
--- a/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
@@ -2,13 +2,11 @@ package jobterview.api.question.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jobterview.api.question.response.QuestionDetailResponse
 import jobterview.api.question.response.QuestionResponse
 import jobterview.api.question.service.QuestionService
 import jobterview.common.response.ApiResponse
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.util.*
 
 @RestController
@@ -18,9 +16,15 @@ class QuestionController(
     private val questionService: QuestionService
 ){
 
-    @Operation(summary = "직업별 면접 질문 조회")
+    @Operation(summary = "직업별 질문 조회")
     @GetMapping
     fun getQuestionsByJob(@RequestParam jobId: UUID): ApiResponse<List<QuestionResponse>> {
         return ApiResponse.create(questionService.getQuestionsByJob(jobId))
+    }
+
+    @Operation(summary = "질문 상세 조회")
+    @GetMapping("/{id}")
+    fun getDetail(@PathVariable id: UUID): ApiResponse<QuestionDetailResponse> {
+        return ApiResponse.create(questionService.getDetail(id))
     }
 }

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/response/QuestionDetailResponse.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/response/QuestionDetailResponse.kt
@@ -1,0 +1,26 @@
+package jobterview.api.question.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jobterview.domain.question.Question
+import java.util.*
+
+data class QuestionDetailResponse(
+    @Schema(description = "질문 ID")
+    val id: UUID,
+
+    @Schema(description = "질문 내용")
+    val content: String,
+
+    @Schema(description = "질문 난이도")
+    val difficulty: String,
+
+    @Schema(description = "질문 답변 예시")
+    val answer: String,
+) {
+    constructor(question: Question) : this(
+        id = question.id,
+        content = question.content,
+        difficulty = question.difficulty.code,
+        answer = question.answer
+    )
+}

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
@@ -1,6 +1,9 @@
 package jobterview.api.question.service
 
+import jobterview.api.question.response.QuestionDetailResponse
 import jobterview.api.question.response.QuestionResponse
+import jobterview.domain.question.Question
+import jobterview.domain.question.exception.QuestionException
 import jobterview.domain.question.repository.QuestionJpaRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,5 +18,15 @@ class QuestionService (
     fun getQuestionsByJob(jobId: UUID): List<QuestionResponse> {
         return questionRepository.findAllByJob_Id(jobId)
             .map { QuestionResponse(it) }
+    }
+
+    @Transactional(readOnly = true)
+    fun getDetail(id: UUID): QuestionDetailResponse {
+        return QuestionDetailResponse(getById(id))
+    }
+
+    private fun getById(id: UUID): Question {
+        return questionRepository.findById(id)
+            .orElseThrow { QuestionException.notFound() }
     }
 }

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/question/Question.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/question/Question.kt
@@ -17,13 +17,17 @@ class Question (
     @Column(updatable = false, nullable = false)
     val id: UUID = Generators.timeBasedEpochGenerator().generate(),
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "text", nullable = false)
     @Comment("질문")
     var content: String,
 
     @Convert(converter = QuestionDifficultyEnumConverter::class)
     @Column(nullable = false)
     val difficulty: QuestionDifficulty,
+
+    @Column(columnDefinition = "text", nullable = false)
+    @Comment("답변")
+    var answer: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_id")

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/question/exception/QuestionException.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/question/exception/QuestionException.kt
@@ -1,0 +1,19 @@
+package jobterview.domain.question.exception
+
+import jobterview.common.exception.ApiException
+
+class QuestionException(
+    private val statusCode: Int,
+    override val message: String,
+) : ApiException(message) {
+
+    override fun statusCode(): Int {
+        return statusCode
+    }
+
+    companion object {
+        fun notFound(): QuestionException {
+            return QuestionException(statusCode = 404, message = "질문이 존재하지 않습니다.")
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

#33

## ✅ 작업 내용

- 질문 테이블에 답변 컬럼을 추가하고, 질문 상세 조회 API를 구현했습니다.

