### PR TITLE
feat: 질문 목록 조회 API에 페이징 및 정렬, 검색 옵션 적용

### DIFF
--- a/buildSrc/src/main/kotlin/spring-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/spring-conventions.gradle.kts
@@ -16,6 +16,8 @@ allOpen {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/jobterview-api/src/main/kotlin/jobterview/api/ServerApplication.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/ServerApplication.kt
@@ -4,10 +4,12 @@ import jobterview.batch.config.MailAsyncConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication(
     scanBasePackages = ["jobterview.api", "jobterview.domain", "jobterview.mail", "jobterview.security", "jobterview.common"],
 )
+@EnableJpaRepositories(basePackages = ["jobterview.api"])
 @Import(MailAsyncConfig::class)
 class ServerApplication
 

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
@@ -2,10 +2,15 @@ package jobterview.api.question.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import jobterview.api.question.response.QuestionDetailResponse
 import jobterview.api.question.response.QuestionResponse
 import jobterview.api.question.service.QuestionService
+import jobterview.api.question.vo.QuestionFilter
 import jobterview.common.response.ApiResponse
+import jobterview.domain.question.enums.QuestionDifficulty
+import org.springframework.data.domain.Page
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
@@ -16,10 +21,21 @@ class QuestionController(
     private val questionService: QuestionService
 ){
 
-    @Operation(summary = "직업별 질문 조회")
+    @Operation(summary = "질문 목록 조회")
     @GetMapping
-    fun getQuestionsByJob(@RequestParam jobId: UUID): ApiResponse<List<QuestionResponse>> {
-        return ApiResponse.create(questionService.getQuestionsByJob(jobId))
+    fun getQuestions(
+        @RequestParam jobId: UUID?,
+        @RequestParam difficulty: String?,
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "10") @Min(1) @Max(100) size: Int,
+    ): ApiResponse<Page<QuestionResponse>> {
+        val filter =
+            QuestionFilter(
+                jobId = jobId,
+                difficulty = difficulty?.let { QuestionDifficulty.fromCode(it) },
+            )
+
+        return ApiResponse.create(questionService.getQuestions(filter, page, size))
     }
 
     @Operation(summary = "질문 상세 조회")

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
@@ -28,6 +28,7 @@ class QuestionController(
     fun getQuestions(
         @RequestParam jobId: UUID?,
         @RequestParam difficulty: String?,
+        @RequestParam searchKeyword: String?,
         @RequestParam(defaultValue = "0") @Min(0) page: Int,
         @RequestParam(defaultValue = "10") @Min(1) @Max(100) size: Int,
         @RequestParam(defaultValue = "createdAt") sort: String,
@@ -37,6 +38,7 @@ class QuestionController(
             QuestionFilter(
                 jobId = jobId,
                 difficulty = difficulty?.let { QuestionDifficulty.fromCode(it) },
+                searchKeyword = searchKeyword
             )
 
         val sortDirection = Sort.Direction.fromOptionalString(direction.uppercase()).orElse(Sort.Direction.DESC)

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/controller/QuestionController.kt
@@ -11,6 +11,8 @@ import jobterview.api.question.vo.QuestionFilter
 import jobterview.common.response.ApiResponse
 import jobterview.domain.question.enums.QuestionDifficulty
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
@@ -28,6 +30,8 @@ class QuestionController(
         @RequestParam difficulty: String?,
         @RequestParam(defaultValue = "0") @Min(0) page: Int,
         @RequestParam(defaultValue = "10") @Min(1) @Max(100) size: Int,
+        @RequestParam(defaultValue = "createdAt") sort: String,
+        @RequestParam(defaultValue = "desc") direction: String,
     ): ApiResponse<Page<QuestionResponse>> {
         val filter =
             QuestionFilter(
@@ -35,7 +39,10 @@ class QuestionController(
                 difficulty = difficulty?.let { QuestionDifficulty.fromCode(it) },
             )
 
-        return ApiResponse.create(questionService.getQuestions(filter, page, size))
+        val sortDirection = Sort.Direction.fromOptionalString(direction.uppercase()).orElse(Sort.Direction.DESC)
+        val pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort))
+
+        return ApiResponse.create(questionService.getQuestions(filter, pageable))
     }
 
     @Operation(summary = "질문 상세 조회")

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/repository/QuestionRepository.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/repository/QuestionRepository.kt
@@ -1,0 +1,7 @@
+package jobterview.api.question.repository
+
+import jobterview.api.question.repository.custom.CustomQuestionRepository
+import jobterview.domain.question.repository.QuestionJpaRepository
+
+interface QuestionRepository : QuestionJpaRepository, CustomQuestionRepository {
+}

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepository.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepository.kt
@@ -1,0 +1,11 @@
+package jobterview.api.question.repository.custom
+
+import jobterview.api.question.response.QuestionResponse
+import jobterview.api.question.vo.QuestionFilter
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface CustomQuestionRepository {
+
+    fun getQuestions(filter: QuestionFilter, pageable: Pageable): Page<QuestionResponse>
+}

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepositoryImpl.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package jobterview.api.question.repository.custom
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jobterview.api.question.response.QuestionResponse
+import jobterview.api.question.vo.QuestionFilter
+import jobterview.domain.job.QJob.job
+import jobterview.domain.question.QQuestion.question
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
+
+class CustomQuestionRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : CustomQuestionRepository {
+
+    override fun getQuestions(filter: QuestionFilter, pageable: Pageable): Page<QuestionResponse> {
+        val builder = BooleanBuilder()
+            .apply {
+                filter.jobId?.let {
+                    and(question.jobId.eq(it))
+                }
+                filter.difficulty?.let {
+                    and(question.difficulty.eq(it))
+                }
+            }
+
+        val results = queryFactory
+            .select(
+                Projections.constructor(
+                    QuestionResponse::class.java,
+                    question,
+                    job
+                )
+            )
+            .from(question)
+            .join(job)
+            .on(question.jobId.eq(job.id))
+            .where(builder)
+            .orderBy(question.createdAt.asc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        return PageableExecutionUtils.getPage(results, pageable) {
+            queryFactory
+                .select(question.id.count())
+                .from(question)
+                .where(builder)
+                .fetchOne() ?: 0L
+        }
+    }
+}

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepositoryImpl.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepositoryImpl.kt
@@ -26,6 +26,9 @@ class CustomQuestionRepositoryImpl(
                 filter.difficulty?.let {
                     and(question.difficulty.eq(it))
                 }
+                filter.searchKeyword?.let {
+                    and(question.content.containsIgnoreCase(it))
+                }
             }
 
         val orderSpecifiers = pageable.sort.mapNotNull { order ->

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/response/QuestionResponse.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/response/QuestionResponse.kt
@@ -1,6 +1,7 @@
 package jobterview.api.question.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jobterview.domain.job.Job
 import jobterview.domain.question.Question
 import java.util.*
 
@@ -13,10 +14,25 @@ data class QuestionResponse(
 
     @Schema(description = "질문 난이도")
     val difficulty: String,
+
+    @Schema(description = "직업 정보")
+    val job: JobInfo
 ) {
-    constructor(question: Question) : this(
+    constructor(question: Question, job: Job) : this(
         id = question.id,
         content = question.content,
-        difficulty = question.difficulty.code
+        difficulty = question.difficulty.code,
+        job = JobInfo(
+            id = job.id,
+            position = job.position
+        )
+    )
+
+    data class JobInfo(
+        @Schema(description = "직업 ID")
+        val id: UUID,
+
+        @Schema(description = "포지션")
+        val position: String
     )
 }

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
@@ -1,23 +1,31 @@
 package jobterview.api.question.service
 
+import jobterview.api.question.repository.QuestionRepository
 import jobterview.api.question.response.QuestionDetailResponse
 import jobterview.api.question.response.QuestionResponse
+import jobterview.api.question.vo.QuestionFilter
 import jobterview.domain.question.Question
 import jobterview.domain.question.exception.QuestionException
-import jobterview.domain.question.repository.QuestionJpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @Service
 class QuestionService (
-    private val questionRepository: QuestionJpaRepository
+    private val questionRepository: QuestionRepository
 ){
 
     @Transactional(readOnly = true)
-    fun getQuestionsByJob(jobId: UUID): List<QuestionResponse> {
-        return questionRepository.findAllByJob_Id(jobId)
-            .map { QuestionResponse(it) }
+    fun getQuestions(
+        filter: QuestionFilter,
+        page: Int,
+        size: Int
+    ): Page<QuestionResponse> {
+        val pageable = PageRequest.of(page, size)
+
+        return questionRepository.getQuestions(filter, pageable)
     }
 
     @Transactional(readOnly = true)

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
@@ -20,11 +20,8 @@ class QuestionService (
     @Transactional(readOnly = true)
     fun getQuestions(
         filter: QuestionFilter,
-        page: Int,
-        size: Int
+        pageable: PageRequest,
     ): Page<QuestionResponse> {
-        val pageable = PageRequest.of(page, size)
-
         return questionRepository.getQuestions(filter, pageable)
     }
 

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/vo/QuestionFilter.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/vo/QuestionFilter.kt
@@ -6,4 +6,5 @@ import java.util.*
 data class QuestionFilter(
     val jobId: UUID? = null,
     val difficulty: QuestionDifficulty? = null,
+    val searchKeyword: String? = null,
 )

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/vo/QuestionFilter.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/vo/QuestionFilter.kt
@@ -1,0 +1,9 @@
+package jobterview.api.question.vo
+
+import jobterview.domain.question.enums.QuestionDifficulty
+import java.util.*
+
+data class QuestionFilter(
+    val jobId: UUID? = null,
+    val difficulty: QuestionDifficulty? = null,
+)

--- a/jobterview-batch/src/main/kotlin/jobterview/batch/question/repository/custom/CustomQuestionRepositoryImpl.kt
+++ b/jobterview-batch/src/main/kotlin/jobterview/batch/question/repository/custom/CustomQuestionRepositoryImpl.kt
@@ -15,7 +15,7 @@ class CustomQuestionRepositoryImpl(
         return queryFactory
             .selectFrom(question)
             .where(
-                question.job().id.eq(jobId),
+                question.jobId.eq(jobId),
                 question.id.notIn(
                     JPAExpressions
                         .select(sentQuestion.question().id)

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/question/Question.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/question/Question.kt
@@ -3,7 +3,6 @@ package jobterview.domain.question
 import com.fasterxml.uuid.Generators
 import jakarta.persistence.*
 import jobterview.domain.common.audit.CreatedTimeEntity
-import jobterview.domain.job.Job
 import jobterview.domain.question.enums.QuestionDifficulty
 import jobterview.domain.question.enums.QuestionDifficultyEnumConverter
 import org.hibernate.annotations.Comment
@@ -17,6 +16,10 @@ class Question (
     @Column(updatable = false, nullable = false)
     val id: UUID = Generators.timeBasedEpochGenerator().generate(),
 
+    @Column(nullable = false)
+    @Comment("직업 ID")
+    val jobId: UUID,
+
     @Column(columnDefinition = "text", nullable = false)
     @Comment("질문")
     var content: String,
@@ -28,8 +31,4 @@ class Question (
     @Column(columnDefinition = "text", nullable = false)
     @Comment("답변")
     var answer: String,
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_id")
-    val job: Job,
 ): CreatedTimeEntity()

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/question/enums/QuestionDifficulty.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/question/enums/QuestionDifficulty.kt
@@ -5,5 +5,11 @@ import jobterview.domain.common.enums.Codable
 enum class QuestionDifficulty(override val code: String): Codable {
     EASY("easy"),
     MEDIUM("medium"),
-    HARD("hard")
+    HARD("hard");
+
+    companion object {
+        fun fromCode(code: String?): QuestionDifficulty? {
+            return Codable.fromCode(QuestionDifficulty::class.java, code)
+        }
+    }
 }

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/question/repository/QuestionJpaRepository.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/question/repository/QuestionJpaRepository.kt
@@ -6,5 +6,4 @@ import java.util.*
 
 interface QuestionJpaRepository : JpaRepository<Question, UUID> {
 
-    fun findAllByJob_Id(jobId: UUID): List<Question>
 }


### PR DESCRIPTION
## 📌 관련 이슈

#35

## ✅ 작업 내용

- 질문 목록 조회 API에 페이징을 적용했습니다.
- 정렬 옵션을 추가했습니다.
- 질문 검색 옵션을 추가했습니다.


