### PR TITLE
feat: 이메일별 전송된 질문 목록 조회 API 구현

### DIFF
--- a/jobterview-api/src/main/kotlin/jobterview/api/question/controller/EmailQuestionController.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/controller/EmailQuestionController.kt
@@ -1,0 +1,53 @@
+package jobterview.api.question.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jobterview.api.question.response.QuestionResponse
+import jobterview.api.question.service.EmailQuestionService
+import jobterview.api.question.vo.QuestionFilter
+import jobterview.common.response.ApiResponse
+import jobterview.domain.question.enums.QuestionDifficulty
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+
+@RestController
+@RequestMapping("/email-questions")
+@Tag(name = "Email Question")
+class EmailQuestionController (
+    private val emailQuestionService: EmailQuestionService
+) {
+
+    @Operation(summary = "이메일별 전송된 질문 목록 조회")
+    @GetMapping
+    fun getQuestionsByEmail(
+        @RequestParam email: String,
+        @RequestParam token: String,
+        @RequestParam jobId: UUID?,
+        @RequestParam difficulty: String?,
+        @RequestParam searchKeyword: String?,
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "10") @Min(1) @Max(100) size: Int,
+        @RequestParam(defaultValue = "createdAt") sort: String,
+        @RequestParam(defaultValue = "desc") direction: String,
+    ): ApiResponse<Page<QuestionResponse>> {
+        val filter =
+            QuestionFilter(
+                jobId = jobId,
+                difficulty = difficulty?.let { QuestionDifficulty.fromCode(it) },
+                searchKeyword = searchKeyword
+            )
+
+        val sortDirection = Sort.Direction.fromOptionalString(direction.uppercase()).orElse(Sort.Direction.DESC)
+        val pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort))
+
+        return ApiResponse.create(emailQuestionService.getQuestionsByEmail(email, token, filter, pageable))
+    }
+}

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepository.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepository.kt
@@ -8,4 +8,6 @@ import org.springframework.data.domain.Pageable
 interface CustomQuestionRepository {
 
     fun getQuestions(filter: QuestionFilter, pageable: Pageable): Page<QuestionResponse>
+
+    fun getQuestionsByEmail(email: String, filter: QuestionFilter, pageable: Pageable): Page<QuestionResponse>
 }

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepositoryImpl.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/repository/custom/CustomQuestionRepositoryImpl.kt
@@ -9,8 +9,10 @@ import jobterview.api.question.response.QuestionResponse
 import jobterview.api.question.vo.QuestionFilter
 import jobterview.domain.job.QJob.job
 import jobterview.domain.question.QQuestion.question
+import jobterview.domain.question.QSentQuestion.sentQuestion
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.data.support.PageableExecutionUtils
 
 class CustomQuestionRepositoryImpl(
@@ -18,30 +20,8 @@ class CustomQuestionRepositoryImpl(
 ) : CustomQuestionRepository {
 
     override fun getQuestions(filter: QuestionFilter, pageable: Pageable): Page<QuestionResponse> {
-        val conditionBuilder = BooleanBuilder()
-            .apply {
-                filter.jobId?.let {
-                    and(question.jobId.eq(it))
-                }
-                filter.difficulty?.let {
-                    and(question.difficulty.eq(it))
-                }
-                filter.searchKeyword?.let {
-                    and(question.content.containsIgnoreCase(it))
-                }
-            }
-
-        val orderSpecifiers = pageable.sort.mapNotNull { order ->
-            val direction = if (order.isAscending) Order.ASC else Order.DESC
-
-            when (order.property) {
-                "createdAt" -> OrderSpecifier(direction, question.createdAt)
-                "content" -> OrderSpecifier(direction, question.content)
-                "difficulty" -> OrderSpecifier(direction, question.difficulty)
-                "position" -> OrderSpecifier(direction, job.position)
-                else -> null
-            }
-        }.toTypedArray()
+        val conditionBuilder = createConditionBuilder(filter)
+        val orderSpecifiers = createOrderSpecifiers(pageable.sort)
 
         val results = queryFactory
             .select(
@@ -67,5 +47,72 @@ class CustomQuestionRepositoryImpl(
                 .where(conditionBuilder)
                 .fetchOne() ?: 0L
         }
+    }
+
+    override fun getQuestionsByEmail(email: String, filter: QuestionFilter, pageable: Pageable): Page<QuestionResponse> {
+        val conditionBuilder = createConditionBuilder(filter)
+        val orderSpecifiers = createOrderSpecifiers(pageable.sort)
+
+        val results = queryFactory
+            .select(
+                Projections.constructor(
+                    QuestionResponse::class.java,
+                    question,
+                    job
+                )
+            )
+            .from(question)
+            .innerJoin(job).on(question.jobId.eq(job.id))
+            .innerJoin(sentQuestion).on(
+                sentQuestion.email.eq(email)
+                    .and(sentQuestion.questionId.eq(question.id))
+            )
+            .where(conditionBuilder)
+            .orderBy(*orderSpecifiers)
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        return PageableExecutionUtils.getPage(results, pageable) {
+            queryFactory
+                .select(question.count())
+                .from(question)
+                .innerJoin(job).on(question.jobId.eq(job.id))
+                .innerJoin(sentQuestion).on(
+                    sentQuestion.email.eq(email)
+                        .and(sentQuestion.questionId.eq(question.id))
+                )
+                .where(conditionBuilder)
+                .fetchOne() ?: 0L
+        }
+    }
+
+    private fun createConditionBuilder(filter: QuestionFilter): BooleanBuilder {
+        return BooleanBuilder()
+            .apply {
+                filter.jobId?.let {
+                    and(question.jobId.eq(it))
+                }
+                filter.difficulty?.let {
+                    and(question.difficulty.eq(it))
+                }
+                filter.searchKeyword?.let {
+                    and(question.content.containsIgnoreCase(it))
+                }
+            }
+    }
+
+    fun createOrderSpecifiers(sort: Sort): Array<OrderSpecifier<*>> {
+        return sort.mapNotNull { order ->
+            val direction = if (order.isAscending) Order.ASC else Order.DESC
+
+            when (order.property) {
+                "createdAt" -> OrderSpecifier(direction, question.createdAt)
+                "content" -> OrderSpecifier(direction, question.content)
+                "difficulty" -> OrderSpecifier(direction, question.difficulty)
+                "position" -> OrderSpecifier(direction, job.position)
+                else -> null
+            }
+        }.toTypedArray()
     }
 }

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/service/EmailQuestionService.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/service/EmailQuestionService.kt
@@ -1,0 +1,33 @@
+package jobterview.api.question.service
+
+import jobterview.api.question.repository.QuestionRepository
+import jobterview.api.question.response.QuestionResponse
+import jobterview.api.question.vo.QuestionFilter
+import jobterview.domain.mail.exception.MailTokenException
+import jobterview.domain.mail.repository.MailTokenJpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+
+@Service
+class EmailQuestionService (
+    private val questionRepository: QuestionRepository,
+    private val mailTokenRepository: MailTokenJpaRepository
+) {
+
+    fun getQuestionsByEmail(
+        email: String,
+        token: String,
+        filter: QuestionFilter,
+        pageable: PageRequest,
+    ): Page<QuestionResponse> {
+        val mailToken = mailTokenRepository.findById(email)
+            .orElseThrow { MailTokenException.invalid() }
+
+        if (mailToken.token != token) {
+            throw MailTokenException.invalid()
+        }
+
+        return questionRepository.getQuestionsByEmail(email, filter, pageable)
+    }
+}

--- a/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/question/service/QuestionService.kt
@@ -15,7 +15,7 @@ import java.util.*
 @Service
 class QuestionService (
     private val questionRepository: QuestionRepository
-){
+) {
 
     @Transactional(readOnly = true)
     fun getQuestions(

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/mail/MailToken.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/mail/MailToken.kt
@@ -1,0 +1,21 @@
+package jobterview.domain.mail
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Comment
+
+@Entity
+@Table(name = "mail_token")
+@Comment("메일 토큰")
+class MailToken (
+
+    @Id
+    @Column(nullable = false)
+    @Comment("이메일")
+    val email: String,
+
+    @Column(nullable = false, unique = true)
+    val token: String
+)

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/mail/exception/MailTokenException.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/mail/exception/MailTokenException.kt
@@ -1,0 +1,19 @@
+package jobterview.domain.mail.exception
+
+import jobterview.common.exception.ApiException
+
+class MailTokenException(
+    private val statusCode: Int,
+    override val message: String,
+) : ApiException(message) {
+
+    override fun statusCode(): Int {
+        return statusCode
+    }
+
+    companion object {
+        fun invalid(): MailTokenException {
+            return MailTokenException(400, "유효하지 않은 인증 정보입니다.")
+        }
+    }
+}

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/mail/repository/MailTokenJpaRepository.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/mail/repository/MailTokenJpaRepository.kt
@@ -1,0 +1,7 @@
+package jobterview.domain.mail.repository
+
+import jobterview.domain.mail.MailToken
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MailTokenJpaRepository : JpaRepository<MailToken, String> {
+}

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/question/SentQuestion.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/question/SentQuestion.kt
@@ -9,7 +9,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jobterview.domain.common.audit.CreatedTimeEntity
-import jobterview.domain.job.Job
 import jobterview.domain.subscription.Subscription
 import org.hibernate.annotations.Comment
 import java.util.*
@@ -25,6 +24,9 @@ class SentQuestion (
     @Column(nullable = false)
     @Comment("이메일")
     var email: String,
+
+    @Column(name = "question_id", insertable = false, updatable = false)
+    val questionId: UUID,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")


### PR DESCRIPTION
## 📌 관련 이슈

#37

## ✅ 작업 내용

- `email_token` 엔티티 정의
- 이메일 인증 토큰 생성 로직(첫 구독 시 발급)을 구현했습니다. 
- 이메일별 전송된 질문 목록 조회 API를 구현했습니다.


