### PR TITLE
feat: 이메일별 구독 정보 목록 조회 및 구독 해제 API 구현

### DIFF
--- a/jobterview-api/src/main/kotlin/jobterview/api/subscription/controller/SubscriptionController.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/subscription/controller/SubscriptionController.kt
@@ -4,10 +4,14 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jobterview.api.subscription.request.SubscriptRequest
 import jobterview.api.subscription.request.VerifyEmailRequest
+import jobterview.api.subscription.response.SubscriptionResponse
 import jobterview.api.subscription.service.SubscriptionService
+import jobterview.common.response.ApiResponse
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -27,5 +31,14 @@ class SubscriptionController (
     @PostMapping
     fun subscript(@RequestBody request: SubscriptRequest) {
         subscriptionService.subscript(request)
+    }
+
+    @Operation(summary = "이메일별 구독 정보 목록 조회")
+    @GetMapping
+    fun getSubscriptionsByEmail(
+        @RequestParam email: String,
+        @RequestParam token: String
+    ): ApiResponse<List<SubscriptionResponse>> {
+        return ApiResponse.create(subscriptionService.getSubscriptions(email, token))
     }
 }

--- a/jobterview-api/src/main/kotlin/jobterview/api/subscription/controller/SubscriptionController.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/subscription/controller/SubscriptionController.kt
@@ -7,12 +7,15 @@ import jobterview.api.subscription.request.VerifyEmailRequest
 import jobterview.api.subscription.response.SubscriptionResponse
 import jobterview.api.subscription.service.SubscriptionService
 import jobterview.common.response.ApiResponse
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.util.*
 
 @RestController
 @RequestMapping("/subscriptions")
@@ -40,5 +43,15 @@ class SubscriptionController (
         @RequestParam token: String
     ): ApiResponse<List<SubscriptionResponse>> {
         return ApiResponse.create(subscriptionService.getSubscriptions(email, token))
+    }
+
+    @Operation(summary = "구독 해제")
+    @DeleteMapping("/{id}")
+    fun unsubscribe(
+        @PathVariable id: UUID,
+        @RequestParam email: String,
+        @RequestParam token: String
+    ) {
+        subscriptionService.unsubscribe(id, email, token)
     }
 }

--- a/jobterview-api/src/main/kotlin/jobterview/api/subscription/response/SubscriptionResponse.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/subscription/response/SubscriptionResponse.kt
@@ -1,0 +1,29 @@
+package jobterview.api.subscription.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jobterview.domain.subscription.Subscription
+import java.util.*
+
+data class SubscriptionResponse(
+    @Schema(description = "구독 ID")
+    val id: UUID,
+
+    @Schema(description = "직업 정보")
+    val job: JobInfo
+) {
+    constructor(subscription: Subscription) : this(
+        id = subscription.id,
+        job = JobInfo(
+            id = subscription.job.id,
+            position = subscription.job.position
+        )
+    )
+
+    data class JobInfo(
+        @Schema(description = "직업 ID")
+        val id: UUID,
+
+        @Schema(description = "포지션")
+        val position: String
+    )
+}

--- a/jobterview-api/src/main/kotlin/jobterview/api/subscription/service/SubscriptionService.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/subscription/service/SubscriptionService.kt
@@ -4,8 +4,10 @@ import com.fasterxml.uuid.Generators
 import jobterview.api.job.service.JobService
 import jobterview.api.subscription.request.SubscriptRequest
 import jobterview.api.subscription.request.VerifyEmailRequest
+import jobterview.api.subscription.response.SubscriptionResponse
 import jobterview.domain.mail.MailToken
 import jobterview.domain.mail.MailVerification
+import jobterview.domain.mail.exception.MailTokenException
 import jobterview.domain.mail.exception.MailVerificationException
 import jobterview.domain.mail.repository.MailTokenJpaRepository
 import jobterview.domain.mail.repository.MailVerificationJpaRepository
@@ -22,7 +24,6 @@ import java.util.*
 
 
 @Service
-@Transactional
 class SubscriptionService (
     private val mailSender: MailSender,
     private val verifyMailTemplate: VerifyMailTemplate,
@@ -32,6 +33,7 @@ class SubscriptionService (
     private val jobService: JobService
 ){
 
+    @Transactional
     fun sendVerifyEmail(request: VerifyEmailRequest) {
         jobService.verifyExist(request.jobId)
         if (subscriptionRepository.existsByEmailAndJob_Id(request.email, request.jobId)) {
@@ -53,6 +55,7 @@ class SubscriptionService (
         mailVerificationRepository.save(mailVerification)
     }
 
+    @Transactional
     fun subscript(request: SubscriptRequest) {
         verifyCode(request.email, request.jobId, request.code)
 
@@ -73,6 +76,14 @@ class SubscriptionService (
         }
     }
 
+    @Transactional(readOnly = true)
+    fun getSubscriptions(email: String, token: String): List<SubscriptionResponse> {
+        verifyToken(email, token)
+
+        return subscriptionRepository.findAllByEmailOrderByCreatedAtDesc(email)
+            .map { SubscriptionResponse(it) }
+    }
+
     private fun verifyCode(email: String, jobId: UUID, code: String) {
         val mailVerification = mailVerificationRepository.findTopByEmailAndJobIdOrderByCreatedAtDesc(email, jobId)
             .orElseThrow { MailVerificationException.invalid() }
@@ -85,6 +96,12 @@ class SubscriptionService (
             mailVerification.verified()
         } else {
             throw MailVerificationException.mismatch()
+        }
+    }
+
+    private fun verifyToken(email: String, token: String) {
+        if (!mailTokenRepository.existsByEmailAndToken(email, token)) {
+            throw MailTokenException.invalid()
         }
     }
 

--- a/jobterview-api/src/main/kotlin/jobterview/api/subscription/service/SubscriptionService.kt
+++ b/jobterview-api/src/main/kotlin/jobterview/api/subscription/service/SubscriptionService.kt
@@ -31,7 +31,7 @@ class SubscriptionService (
     private val mailVerificationRepository: MailVerificationJpaRepository,
     private val mailTokenRepository: MailTokenJpaRepository,
     private val jobService: JobService
-){
+) {
 
     @Transactional
     fun sendVerifyEmail(request: VerifyEmailRequest) {
@@ -82,6 +82,16 @@ class SubscriptionService (
 
         return subscriptionRepository.findAllByEmailOrderByCreatedAtDesc(email)
             .map { SubscriptionResponse(it) }
+    }
+
+    @Transactional
+    fun unsubscribe(id: UUID, email: String, token: String) {
+        verifyToken(email, token)
+
+        val subscription = subscriptionRepository.findByIdAndEmail(id, email)
+            ?: throw SubscriptionException.notFound()
+
+        subscriptionRepository.delete(subscription)
     }
 
     private fun verifyCode(email: String, jobId: UUID, code: String) {

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/mail/repository/MailTokenJpaRepository.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/mail/repository/MailTokenJpaRepository.kt
@@ -4,4 +4,6 @@ import jobterview.domain.mail.MailToken
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MailTokenJpaRepository : JpaRepository<MailToken, String> {
+
+    fun existsByEmailAndToken(email: String, token: String): Boolean
 }

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/subscription/repository/SubscriptionJpaRepository.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/subscription/repository/SubscriptionJpaRepository.kt
@@ -11,4 +11,6 @@ interface SubscriptionJpaRepository : JpaRepository<Subscription, UUID> {
 
     @EntityGraph(attributePaths = ["job"])
     fun findAllByEmailOrderByCreatedAtDesc(email: String): List<Subscription>
+
+    fun findByIdAndEmail(id: UUID, email: String): Subscription?
 }

--- a/jobterview-domain/src/main/kotlin/jobterview/domain/subscription/repository/SubscriptionJpaRepository.kt
+++ b/jobterview-domain/src/main/kotlin/jobterview/domain/subscription/repository/SubscriptionJpaRepository.kt
@@ -1,10 +1,14 @@
 package jobterview.domain.subscription.repository
 
 import jobterview.domain.subscription.Subscription
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface SubscriptionJpaRepository : JpaRepository<Subscription, UUID> {
 
     fun existsByEmailAndJob_Id(email: String, jobId: UUID): Boolean
+
+    @EntityGraph(attributePaths = ["job"])
+    fun findAllByEmailOrderByCreatedAtDesc(email: String): List<Subscription>
 }


### PR DESCRIPTION
## 📌 관련 이슈

#44

## ✅ 작업 내용

- 이메일별 구독 정보 목록 조회 API 구현
- 구독 해제 API 구현


